### PR TITLE
Simplify "video not found" condition

### DIFF
--- a/cmd/ytgo/yt.go
+++ b/cmd/ytgo/yt.go
@@ -54,14 +54,13 @@ func main() {
 		v, err = GetVideoFromURL(query)
 	} else if i {
 		v, err = GetVideoFromMenu(query)
-		if err == nil && v == nil {
-			return
-		}
 	} else {
 		v, err = GetVideoFromSearch(query, n)
 	}
 	if err != nil {
 		log.Fatalln(err)
+	} else if v == nil {
+	    return
 	}
 	if d {
 		fmt.Println(v.Id.URL())

--- a/cmd/ytgo/yt.go
+++ b/cmd/ytgo/yt.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 )
 
-const VERSION string = "v3.0.11"
+const VERSION string = "v3.0.12"
 
 const (
 	C_RED   string = "\x1b[31m"


### PR DESCRIPTION
When there's no video for a given query, but there's no error, the main function returns.

This PR aims to simplify the logic that's used to achieve that effect.